### PR TITLE
Fix pytest 9.0 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,4 +36,4 @@ testing = [
 source = "vcs"
 
 [tool.pytest]
-testpaths = "tests"
+testpaths = ["tests"]


### PR DESCRIPTION
Testpaths must be a list and this is now enforced in pytest 9.0.